### PR TITLE
Add missing state, Fix weekday name , Fix RTL overlapping

### DIFF
--- a/weather-card/README.md
+++ b/weather-card/README.md
@@ -23,7 +23,11 @@ And add a card with type `custom:weather-card`:
   - type: custom:weather-card
     entity: weather.yourweatherentity
 ```
-
+Make sure the `sun` component is enabled:
+```yaml
+# Example configuration.yaml entry
+sun:
+```
 ### Dark Sky:
 When using Dark Sky you should put the mode to `daily` if you want a daily forecast with highs and lows.
 ```yaml

--- a/weather-card/weather-card.js
+++ b/weather-card/weather-card.js
@@ -112,7 +112,7 @@ class WeatherCard extends LitElement {
 
     const stateObj = this.hass.states[this._config.entity];
     const lang = this.hass.selectedLanguage || this.hass.language;
-    
+
     return html`
       ${this.renderStyle()}
       <ha-card @click="${this._handleClick}">
@@ -178,7 +178,7 @@ class WeatherCard extends LitElement {
   getWeatherIcon(condition, sun) {
     return sun == "above_horizon" ? weatherIconsDay[condition] : weatherIconsNight[condition];
   }
-  
+
    getUnit(measure) {
       const lengthUnit = this.hass.config.unit_system.length;
       switch (measure) {
@@ -213,17 +213,17 @@ class WeatherCard extends LitElement {
             padding-right:1em;
             position: relative;
           }
-          
+
           .clear {
             clear: both;
           }
-            
+
           .ha-icon {
             height: 18px;
             margin-right: 5px;
             color: var(--paper-item-icon-color);
           }
-        
+
           .temp {
             font-weight: 300;
             font-size: 4em;
@@ -231,7 +231,7 @@ class WeatherCard extends LitElement {
             position: absolute;
             right: 1em;
           }
-        
+
           .tempc {
             font-weight: 300;
             font-size: 1.5em;
@@ -242,10 +242,11 @@ class WeatherCard extends LitElement {
             margin-top: -14px;
             margin-right: 7px;
           }
-        
+
           .variations {
             display: flex;
             flex-flow:row wrap;
+            justify-content: space-between;
             font-weight: 300;
             color: var(--primary-text-color);
             list-style: none;
@@ -254,19 +255,19 @@ class WeatherCard extends LitElement {
           }
 
           .variations li{
-            flex-basis: 50%; 
+            flex-basis: auto;
           }
 
           .unit {
             font-size: .8em;
           }
-        
+
           .forecast {
             width: 100%;
             margin: 0 auto;
             height: 9em;
           }
-        
+
           .day {
             display: block;
             width: 20%;
@@ -277,28 +278,28 @@ class WeatherCard extends LitElement {
             line-height: 2;
             box-sizing: border-box;
           }
-        
+
           .dayname {
             text-transform: uppercase;
           }
-        
+
           .forecast .day:first-child {
             margin-left: 0;
           }
-        
+
           .forecast .day:nth-last-child(1) {
             border-right: none;
             margin-right: 0;
           }
-        
+
           .highTemp {
             font-weight: bold;
           }
-        
+
           .lowTemp {
             color: var(--secondary-text-color);
           }
-        
+
           .icon.bigger {
             width: 10em;
             height: 10em;
@@ -306,7 +307,7 @@ class WeatherCard extends LitElement {
             position: absolute;
             left: 0em;
           }
-        
+
           .icon {
             width: 50px;
             height: 50px;
@@ -318,7 +319,7 @@ class WeatherCard extends LitElement {
             background-repeat: no-repeat;
             text-indent: -9999px;
           }
-        
+
           .weather {
             font-weight: 300;
             font-size: 1.5em;

--- a/weather-card/weather-card.js
+++ b/weather-card/weather-card.js
@@ -26,6 +26,7 @@ const weatherIconsNight = {
   sunny: "night",
   partlycloudy: "cloudy-night-3",
   "windy-variant": "cloudy-night-3",
+  "clear-night": "night",
 };
 
 const windDirections = [
@@ -118,38 +119,33 @@ class WeatherCard extends LitElement {
           <span
             class="icon bigger"
             style="background: none, url(/local/custom-lovelace/weather-card/icons/${
-              this.getWeatherIcon(stateObj.state.toLowerCase(), this.hass.states["sun.sun"].state)
-            }.svg) no-repeat; background-size: contain;"
-            >${stateObj.state}</span
-          >
-          <span class="temp">${Math.round(stateObj.attributes.temperature)}</span
-          ><span class="tempc"> ${this.getUnit("temperature")}</span>
-          <span>
-            <ul class="variations right">
-              <li>
-                <span class="ha-icon"
-                  ><ha-icon icon="mdi:water-percent"></ha-icon></span
-                >${stateObj.attributes.humidity}<span class="unit"> %</span>
-              </li>
-              <li>
-                <span class="ha-icon"><ha-icon icon="mdi:gauge"></ha-icon></span
-                >${stateObj.attributes.pressure}<span class="unit">
-                  ${this.getUnit("air_pressure")}</span
-                >
-              </li>
-            </ul>
+              this.getWeatherIcon(stateObj.state.toLowerCase(), this.hass.states["sun.sun"].state)}.svg) no-repeat; background-size: contain;">${stateObj.state}
+          </span>
+          <span class="temp">${Math.round(stateObj.attributes.temperature)}</span>
+            <span class="tempc"> ${this.getUnit("temperature")}</span>
+            <span>
             <ul class="variations">
               <li>
-                <span class="ha-icon"
-                  ><ha-icon icon="mdi:weather-windy"></ha-icon></span
-                >${windDirections[(parseInt((stateObj.attributes.wind_bearing + 11.25) / 22.5))]} ${stateObj.attributes.wind_speed}<span class="unit">
-                  ${this.getUnit("length")}/h</span
-                >
+                <span class="ha-icon"><ha-icon icon="mdi:water-percent"></ha-icon></span>
+                  ${stateObj.attributes.humidity}<span class="unit"> %
+                </span>
               </li>
               <li>
                 <span class="ha-icon"
-                  ><ha-icon icon="mdi:weather-fog"></ha-icon></span
-                >${stateObj.attributes.visibility}<span class="unit"> ${this.getUnit("length")}</span>
+                  ><ha-icon icon="mdi:weather-windy"></ha-icon></span>
+                  ${windDirections[(parseInt((stateObj.attributes.wind_bearing + 11.25) / 22.5))]} ${stateObj.attributes.wind_speed}<span class="unit">
+                  ${this.getUnit("length")}/h
+                </span>
+              </li>
+              <li>
+                <span class="ha-icon"><ha-icon icon="mdi:gauge"></ha-icon></span>${stateObj.attributes.pressure}<span class="unit">
+                  ${this.getUnit("air_pressure")}
+                </span>
+              </li>
+              <li>
+                <span class="ha-icon"><ha-icon icon="mdi:weather-fog"></ha-icon></span>
+                ${stateObj.attributes.visibility}<span class="unit"> ${this.getUnit("length")}
+                </span>
               </li>
             </ul>
           </span>
@@ -160,7 +156,7 @@ class WeatherCard extends LitElement {
                   (daily) => html`
                   <div class="day">
                       <span class="dayname">${
-                        new Date(daily.datetime).toLocaleDateString(lang, {weekday: 'short'}).split(" ")[0]
+                        new Date(daily.datetime).toLocaleDateString(lang, {weekday: 'short'})
                       }</span>
                       <br><i class="icon" style="background: none, url(/local/custom-lovelace/weather-card/icons/${
                         weatherIconsDay[daily.condition.toLowerCase()]
@@ -248,21 +244,19 @@ class WeatherCard extends LitElement {
           }
         
           .variations {
-            display: inline-block;
+            display: flex;
+            flex-flow:row wrap;
             font-weight: 300;
             color: var(--primary-text-color);
             list-style: none;
             margin-left: -2em;
             margin-top: 4.5em;
           }
-        
-          .variations.right {
-            position: absolute;
-            right: 1em;
-            margin-left: 0;
-            margin-right: 1em;
+
+          .variations li{
+            flex-basis: 50%; 
           }
-        
+
           .unit {
             font-size: .8em;
           }
@@ -340,5 +334,4 @@ class WeatherCard extends LitElement {
     `;
   }
 }
-
 customElements.define("weather-card", WeatherCard);


### PR DESCRIPTION

* Added weather.dark_sky missing state : "clear-night" icon
* Fix a problem that day name is missing with the Hebrew language selected (may happen in more languages) when using weekday: 'short' (Show Only "day" instead of "day a", "day b" etc ...)
* Fix a problem with RTL languages - when using " .variations " and " variations right" with position: absolute; the variations are overlapping one on other - so I change to "display: flex" to make it be one block (like a table)

Working well on Chrome for Mac, Safari, iOS

* We need to make an RTL support (for the forecast starting from the right side)