### PR TITLE
Changed how daily.templow is evaluated

### DIFF
--- a/weather-card/weather-card.js
+++ b/weather-card/weather-card.js
@@ -245,7 +245,7 @@ class WeatherCard extends LitElement {
                             }</span
                           >
                           ${
-                            daily.templow
+                            typeof daily.templow !== 'undefined'
                               ? html`
                                   <br /><span class="lowTemp"
                                     >${daily.templow}${


### PR DESCRIPTION
I noticed that the check if `daily.templow` is set/available was causing a temperature of 0⁰ to be hidden entirely in Firefox browsers. I changed the evaluation to check again undefined instead so JavaScript doesn't try to evaluate and ends up coercing a 0 to a false boolean.